### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See [LICENSE](LICENSE) for the full license text.
 
 ### It isn’t working for me!
 
-Make sure the application is running in the system tray, then run `microsoft-edge:https://google.com` using the `Windows` + `R` keys. If that is properly redirected, [file a bug report!](https://github.com/rcmaehl/MSEdgeRedirect/issues/new?assignees=&labels=&template=bug_report.md&title=)
+Make sure the application is running in the system tray, then run `microsoft-edge:https://google.com` using the `Windows` + `R` keys. If that is not properly redirected, [file a bug report!](https://github.com/rcmaehl/MSEdgeRedirect/issues/new?assignees=&labels=&template=bug_report.md&title=)
 
 ### Will searches inside <app name here> still use Bing?
 


### PR DESCRIPTION
Fix a typo: the original version tells how to test that the program is working properly, and states that if it is, a user should submit a bug report. This has been corrected to state that if the program is **not** working properly, a user should file a bug report.