### PR TITLE
Correcting chocolateyuninstall.ps1

### DIFF
--- a/Assets/Choco/MSEdgeRedirect/tools/chocolateyuninstall.ps1
+++ b/Assets/Choco/MSEdgeRedirect/tools/chocolateyuninstall.ps1
@@ -4,7 +4,6 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   softwareName  = 'MSEdgeRedirect'
   fileType      = 'exe'
-  silentArgs    = '/wingetinstall'
   validExitCodes= @(@(0))
 }
 
@@ -14,7 +13,7 @@ $uninstalled = $false
 
 if ($key.Count -eq 1) {
   $key | ForEach-Object {
-    $packageArgs['file'] = "$($_.UninstallString)"
+    $packageArgs['file'] = "$($_.UninstallString.Replace(' /uninstall', ''))"
 
     Uninstall-ChocolateyPackage @packageArgs
   }


### PR DESCRIPTION
Hey @rcmaehl, did some few changes to correct uninstall script as per present codes. Also thanks to @Smart123s for that temporary fix.
Explanation of changes:
Removed `silentArgs` as well as added that temporary fix. My previous code was correct, as I mentioned in https://github.com/rcmaehl/MSEdgeRedirect/issues/28#issuecomment-1057119110 it passes `/wingetinstall` argument for uninstalling (in previous code)(both winget and choco but it's possible in choco to give two seperate arguments for install and uninstall but not in winget (that feature in winget got deprecated 🙄) so I recommended `/wingetinstall` for both install and uninstall). With removing `silentArgs` and not adding temporary fix choco has default Argument `/uninstall` which is not supported by mser (that's why I overrode using `silentArgs`) and now it's patched using the temporary fix.

Hey @Smart123s there's a small unnecessary code in your [chocolateyuninstall.ps1](https://github.com/Smart123s/chocolatey-packages/blob/master/msedgeredirect/tools/chocolateyuninstall.ps1), https://github.com/Smart123s/chocolatey-packages/blob/caab0e3a9f67b52dfdc1b6d28d054da8961f76da/msedgeredirect/tools/chocolateyuninstall.ps1#L6 is not needed as the default argument is `/uninstall` and that parameter is used to override it 😊. You can check using `write-output "uninstalling from $($_.UninstallString)"` after this [line](https://github.com/gnpaone/MSEdgeRedirect/blob/49d3ff772c8e796f2a79d0c431197c8660b5d8e2/Assets/Choco/MSEdgeRedirect/tools/chocolateyuninstall.ps1#L16) in your [code](https://github.com/Smart123s/chocolatey-packages/blob/master/msedgeredirect/tools/chocolateyuninstall.ps1)

Hey @rcmaehl is it possible to fix that `4315` error for uninstalling too (it occurs for both winget and choco - my idea is to use /wingetinstall as mentioned above) or **is there any parameter in mser code you included to force stop/kill mser process like for example (in general) `MSEdgeRedirect.exe -<ForceStopParameter>`? - (this idea works only for choco)**
![Screenshot (2) - Copy](https://user-images.githubusercontent.com/78990165/156505677-ce4dec7e-7e73-4b13-ae36-4823dcf8b321.png)

Also @Smart123s, I recommend using `0.6.3.1` version (given below) for testing as installing `0.6.3.0` version in VM may give `4315` error. After `choco install \path\to\msedgeredirect.0.6.3.1.nupkg` you can edit `C:\ProgramData\chocolatey\lib\cheatengine\tools\chocolateyUninstall.ps1` in Notepad administrator mode for testing changes.
[choco.zip](https://github.com/rcmaehl/MSEdgeRedirect/files/8175407/choco.zip)

(Yah, of course it will uninstall from settings as normal)