### PR TITLE
bump cache

### DIFF
--- a/.github/workflows/MSER.yml
+++ b/.github/workflows/MSER.yml
@@ -15,7 +15,7 @@ jobs:
             autoit-v3-setup.exe
             SciTE4AutoIt3.exe
             C:\Program Files (x86)\AutoIt3\SciTE\Au3Stripper
-          key: v2
+          key: v3
       - name: Download tools
         if: steps.cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
see https://github.com/rcmaehl/MSEdgeRedirect/runs/5873691875?check_suite_focus=true#step:6:7

is still using 3.3.14.5