### PR TITLE
Improve Winget workflow

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,38 +1,14 @@
-name: Submit MSEdgeRedirect to winget
+name: Publish to WinGet
 
 on:
   release:
-    types: [published]
-  workflow_dispatch:
+    types: [released]
 
 jobs:
-  winget-bump:
-    name: mser winget
+  publish:
     runs-on: windows-latest
-    if: github.repository == 'rcmaehl/MSEdgeRedirect'
-    defaults:
-      run:
-        shell: bash
     steps:
-      - name: Clone Repository
-        uses: actions/checkout@v2
-      - uses: oprypin/find-latest-tag@v1
+      - uses: vedantmgoyal2009/winget-releaser@latest
         with:
-          repository: rcmaehl/MSEdgeRedirect  # The repository to scan.
-          releases-only: true  # We know that all relevant tags have a GitHub release for them.
-        id: latesttag
-      - name: Set Version
-        id: versionset
-        run: |
-          version="${{ steps.latesttag.outputs.tag }}"
-          echo "::set-output name=version::$version"
-      - name: Submit to winget repository #Name of the workflow step
-        uses: gnpaone/winget-push-test@v1
-        with:
-          version: ${{ steps.versionset.outputs.version }} #Package version
-          url32: https://github.com/rcmaehl/MSEdgeRedirect/releases/download/${{ steps.versionset.outputs.version }}/MSEdgeRedirect.zip #Package url (32-bit)
-          url64: https://github.com/rcmaehl/MSEdgeRedirect/releases/download/${{ steps.versionset.outputs.version }}/MSEdgeRedirect.exe #Package url (64-bit)
-          token:  ${{ secrets.MSEdgeRedirect_PAT }} #Token used to submit to Winget repository
-          packageid: rcmaehl.MSEdgeRedirect #Package ID
-          user: microsoft #Github username where test winget repo exists
-          repo: winget-pkgs #Name of winget test repo
+          identifier: rcmaehl.MSEdgeRedirect
+          token: ${{ secrets.MSEdgeRedirect_PAT }}

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -11,4 +11,5 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@latest
         with:
           identifier: rcmaehl.MSEdgeRedirect
+          delete-previous-version: 'true'
           token: ${{ secrets.MSEdgeRedirect_PAT }}


### PR DESCRIPTION
Use the [Winget Releaser](https://bittu.eu.org/docs/wr-intro) action instead. This significantly simplifies the workflow. You also just only need the `public_repo` scope on your PAT.
![image](https://user-images.githubusercontent.com/56180050/174094570-642a397f-62d9-4242-a072-6d8bfe2f6553.png)

If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro), and the source code is [here](https://github.com/vedantmgoyal2009/winget-releaser).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).