### PR TITLE
Update Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Specific tag name'
+        required: true 
+        type: string
 
 jobs:
   publish:
@@ -13,5 +18,6 @@ jobs:
         with:
           identifier: rcmaehl.MSEdgeRedirect
           version: ${{ github.event.release.tag_name }}
+          release-tag: ${{ inputs.tag_name || github.release.tag_name }}
           delete-previous-version: 'true'
           token: ${{ secrets.MSEdgeRedirect_PAT }}

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: rcmaehl.MSEdgeRedirect
           version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Winget Releaser is now switching to version tags instead of the `latest` tag to prevent errors caused by breaking changes like in https://github.com/rcmaehl/MSEdgeRedirect/pull/147#issuecomment-1259684677.

Additionally, your winget-pkgs fork seems to be missing which is required by the action. Please fork https://github.com/microsoft/winget-pkgs and install the [Pull](https://github.com/apps/pull) app on it to ensure that it is always updated.

