### PR TITLE
Fix version fallback in Winget

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: rcmaehl.MSEdgeRedirect
-          version: ${{ inputs.tag_name || github.release.tag_name || github.ref_name }}
-          release-tag: ${{ inputs.tag_name || github.release.tag_name || github.ref_name }}
+          version: ${{ inputs.tag_name || github.event.release.tag_name }}
+          release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
           delete-previous-version: 'true'
           token: ${{ secrets.MSEdgeRedirect_PAT }}

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: rcmaehl.MSEdgeRedirect
-          version: ${{ inputs.tag_name || github.release.tag_name }}
-          release-tag: ${{ inputs.tag_name || github.release.tag_name }}
+          version: ${{ inputs.tag_name || github.release.tag_name || github.ref_name }}
+          release-tag: ${{ inputs.tag_name || github.release.tag_name || github.ref_name }}
           delete-previous-version: 'true'
           token: ${{ secrets.MSEdgeRedirect_PAT }}


### PR DESCRIPTION
Fix typo. Apparently, [Winget Releaser](https://github.com/vedantmgoyal2009/winget-releaser/blob/58406d89fbdafcbb3f1993b2ad68af30010eac0f/action.yml#L25) has the same typo (fixed in https://github.com/vedantmgoyal2009/winget-releaser/pull/44), but the PR in #184 has the correct value.