### PR TITLE
Bump actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/MSER.yml
+++ b/.github/workflows/MSER.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           Start-Process "${env:ProgramFiles(x86)}\AutoIt3\AutoIt3.exe" "`"${env:ProgramFiles(x86)}\AutoIt3\SciTE\AutoIt3Wrapper\AutoIt3Wrapper.au3`" /NoStatus /prod /in MSEdgeRedirect.au3" -NoNewWindow -Wait
           sha256sum -b MSEdgeRedirect*.exe > checksums.sha256
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: mser
           path: |


### PR DESCRIPTION
To get rid of the warning
https://github.com/rcmaehl/MSEdgeRedirect/actions/runs/6040739085

This was already updated on main 1 year ago by dependabot