### PR TITLE
Get latest version of current repository

### DIFF
--- a/.github/workflows/chocolatey-package.yml
+++ b/.github/workflows/chocolatey-package.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: oprypin/find-latest-tag@v1
         with:
-          repository: rcmaehl/MSEdgeRedirect  # The repository to scan.
+          repository: ${{ github.repository }}  # The repository to scan.
           releases-only: true  # We know that all relevant tags have a GitHub release for them.
         id: latesttag
       - name: Set Checksum


### PR DESCRIPTION
This is not an issue in the main repo, but makes debugging in forks one step easier.