### PR TITLE
Fix Windows Spotlight "Learn more about this picture"

### DIFF
--- a/MSEdgeRedirect.au3
+++ b/MSEdgeRedirect.au3
@@ -617,6 +617,9 @@ Func _DecodeAndRun($sEdge = $aEdges[1], $sCMDLine = "")
 			Else
 				_SafeRun($sEdge, $sCMDLine)
 			EndIf
+		Case StringInStr($sCMDLine, "bing.com/spotlight?spotlightid") ; Fix Windows Spotlight
+			$sCMDLine = StringRegExpReplace($sCMDLine, "spotlight\?spotlightid=[^&]+&", "search?")
+			ContinueCase
 		Case StringInStr($sCMDLine, "&url=") ; Fix Windows 11 Widgets
 			ContinueCase
 		Case StringInStr($sCMDLine, "microsoft-edge:")

--- a/MSEdgeRedirect.au3
+++ b/MSEdgeRedirect.au3
@@ -618,7 +618,7 @@ Func _DecodeAndRun($sEdge = $aEdges[1], $sCMDLine = "")
 				_SafeRun($sEdge, $sCMDLine)
 			EndIf
 		Case StringInStr($sCMDLine, "bing.com/spotlight?spotlightid") ; Fix Windows Spotlight
-			$sCMDLine = StringRegExpReplace($sCMDLine, "spotlight\?spotlightid=[^&]+&", "search?")
+			$sCMDLine = StringRegExpReplace($sCMDLine, "(?i)spotlight\?spotlightid=[^&]+&", "search?")
 			ContinueCase
 		Case StringInStr($sCMDLine, "&url=") ; Fix Windows 11 Widgets
 			ContinueCase


### PR DESCRIPTION
Windows Spotlight creates a *Learn more about this picture* icon on the desktop that on right click opens Spotlight UI and on left click directs to a Bing URL.

When left clicking, this URL is truncated by MSEdgeRedirect causing a 400 error. For example, `https://www.bing.com/spotlight?spotlightid=ParaglidersLakeAchensee&q=Achen+Lake%2C+Tyrol%2C+Austria` becomes `https://www.bing.com/spotlight?spotlightid=ParaglidersLakeAchensee`.

This fix removes the spotlightid (sometimes spotlightId) parameter and converts and replaces the spotlight segment with search, keeping the query parameter,  to redirect the URL to the user preferred search engine.